### PR TITLE
Fix ansible type error comparing 'AnsibleUnicode' and 'int'

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,7 @@ es_default_host: localhost
 es_user: elasticsearch
 es_group: elasticsearch
 es_jvm_config_file: >-
-  {{ (elastic_branch < 7) | ternary('jvm.options', 'jvm.options.d/heap.options') }}
+  {{ (elastic_branch|int < 7) | ternary('jvm.options', 'jvm.options.d/heap.options') }}
 
 es_package_name: >-
   {{ es_use_oss_version | ternary('elasticsearch-oss', 'elasticsearch') }}


### PR DESCRIPTION
I was updating an old ansible from 2.9 to 4.10 and got this error:
> An unhandled exception occurred while templating '{{ (elastic_branch < 7) | ternary('jvm.options', 'jvm.options.d/heap.options') }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on ({{ (elastic_branch < 7) | ternary('jvm.options', 'jvm.options.d/heap.options') }}): '<' not supported between instances of 'AnsibleUnicode' and 'int'

Forcing it to int seems to fix it.